### PR TITLE
Add ALIAS target including namespace

### DIFF
--- a/add-tl.cmake
+++ b/add-tl.cmake
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.8)
 function (tl_add_library name)
   cmake_parse_arguments(ARG "" "" "SOURCES")
   add_library(${name} INTERFACE)
+  add_library("tl::${name}" ALIAS ${name})
   target_sources(${name} INTERFACE 
                  $<BUILD_INTERFACE:${ARG_SOURCES}>)
   target_include_directories(${name} INTERFACE


### PR DESCRIPTION
This makes the target name consistent whether the library is included with `find_package` or `add_subdirectory`.